### PR TITLE
Flush CommandLog after load commands

### DIFF
--- a/src/main/java/seedu/address/logic/CommandLog.java
+++ b/src/main/java/seedu/address/logic/CommandLog.java
@@ -29,7 +29,7 @@ public class CommandLog {
     /**
      * Adds a user input to the stack
      */
-    public void addinput(String input) {
+    public void addInput(String input) {
         inputLog.push(input);
     }
 

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -65,6 +65,7 @@ public class LogicManager implements Logic {
                 ReadOnlyAddressBook loadedAddressBook = loadedAddressBookOpt.get();
                 model.setAddressBook(loadedAddressBook);
                 storage.saveAddressBook(loadedAddressBook);
+                model.emptyCommandLog();
             } catch (CommandException e) {
                 throw e; // Re-throw to maintain custom message if no file is found
             } catch (Exception e) {

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -121,4 +121,9 @@ public interface Model {
      * @return
      */
     String getPreviousInput();
+
+    /**
+     * Flushes the {@code CommandLog}.
+     */
+    void emptyCommandLog();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -189,4 +189,9 @@ public class ModelManager implements Model {
     public String getPreviousInput() {
         return commandLog.getPreviousInput();
     }
+
+    public void emptyCommandLog() {
+        this.commandLog = new CommandLog();
+    }
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -182,7 +182,7 @@ public class ModelManager implements Model {
 
     @Override
     public void addInputToLog(String input) {
-        commandLog.addinput(input);
+        commandLog.addInput(input);
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -192,6 +192,11 @@ public class AddCommandTest {
         public String getPreviousInput() {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void emptyCommandLog() {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes a bug identified in issue #287 by the commandLog after each `load` command to prevent unexpected behaviors with `undo`.  

The undo command was implemented using a `commandLog`, which is a `Stack` storing all commands previously executed.  

The `undo` after `load` bug arises because while we load a different addressBook state, the `commandLog` persists and allows users to undo commands that do not apply to the loaded addressBook. For example, try this sequence of commands in our 1.5.1 release:  

1. Run a `clear` command to obtain an empty addressBook
2. Run a `save` command on this empty addressBook
3. Run an `add` command, like `add n/test`
4. Run `load` command to return to the empty addressBook
5. Run `undo` and see an exception in the terminal

In this case, GamerBook is trying to `undo` the `add` command on the loaded empty state! The user will be exposed to an exception because we are trying to delete a non-existant person. This is just one of many possible unexpected behaviors arising from this functionality bug.  

This PR does not violate the feature freeze by Q3, as we are fixing a bug to ensure that `undo` after `load` follows reasonably correct behavior.